### PR TITLE
Capitalisation fixes (removing ${x~} parameter expansion)

### DIFF
--- a/bl-x-www-browser-pipemenu
+++ b/bl-x-www-browser-pipemenu
@@ -58,18 +58,18 @@ setupOpera() {
 }
 
 if [[ $1 && ! $1 =~ --install-* ]]; then
-    browserExists "${1:2}" || exit 1
-    browserName=${1:2}
-    browserName=${browserName//-/ }
-    terminator --title="Install ${browserName~}" --command="$0 --install-${1:2}"
+    browserName=${1#--}
+    browserExists "$browserName" || exit 1
+    read -ra words <<< "${browserName//-/ }"
+    terminator --title="Install ${words[*]^}" --command="$0 --install-$browserName"
 
 elif [[ $1 = --install-* ]]; then
     packageName=${1#--install-}
-    browserName=${packageName//-/ }
-    browserName=${browserName~}
-    browserNameUpper=${browserName^^}
-
     browserExists "$packageName" || exit 1
+    browserName=${packageName//-/ }
+    read -ra words <<< "$browserName"
+    browserName=${words[*]^}
+    browserNameUpper=${browserName^^}
 
     while true; do # do it until the package is successfully installed or user wants to exit
         if [[ $TRYAGAIN ]]; then # previous try failed
@@ -115,8 +115,8 @@ elif [[ $1 = --install-* ]]; then
 else # pipemenu
     menuStart
     for curTool in "${TOOLS[@]}"; do
-        curToolName=${curTool//-/ }
-        curToolName=${curToolName~}
+        read -ra words <<< "${curTool//-/ }"
+        curToolName=${words[*]^}
         if type "$curTool" &> /dev/null; then
             INSTALLED=true
             menuItem "$curToolName" "$curTool"


### PR DESCRIPTION
This is a twin pull request. (https://github.com/CBPP/cbpp-pipemenus/pull/1)
The problem was first mentioned here:
https://github.com/CBPP/cbpp/issues/11

In short: `setupGoogleChrome` function is probably broken, although it seems like no one has noticed yet :)

There is a detailed explanation in the commit message.

I have not touched the `google-chrome` string. In cbpp it is renamed to `google-chrome-stable`, I'm not sure if that is correct. Therefore, I did not change it.
