### PR TITLE
Double/Single quote fix for remote desktop pipemenu

### DIFF
--- a/bl-remote-desktop-pipemenu
+++ b/bl-remote-desktop-pipemenu
@@ -45,7 +45,7 @@ else
         fi
         menuItem 'VNC Server Preferences' 'vino-preferences'
     else
-        menuItem 'Install VNC Server' "$0 --server'
+        menuItem 'Install VNC Server' '$0 --server'
     fi
 
     menuEnd


### PR DESCRIPTION
Runnning `./bl-remote-desktop-pipement` while in `~/bin` resulted in two errors:

```
/bl-remote-desktop-pipemenu: line 48: unexpected EOF while looking for matching `"'
./bl-remote-desktop-pipemenu: line 54: syntax error: unexpected end of file
```

I substituted a single quote for the double quote that appeared out-of-place. After running again, the errors no longer appeared.
