### PR TITLE
Test if default tint2 command was used

### DIFF
--- a/bl-tint2-pipemenu
+++ b/bl-tint2-pipemenu
@@ -19,22 +19,22 @@ if [ ! -e "$TSESSIONFILE" ] 2> /dev/null ; then
     echo $"Error: Failed to locate tint2-sessionfile in $TINT2PATH" >&2
 fi
 
-tintRunning(){    # find running tint2s
-    if [ "$(pidof tint2)" ];then
-        ps aux | grep [t]tint2" -c" |  awk  '{print $NF}'
-    fi
-}
-
 loadTEditmenu(){
     menuSeparator 
     menuItem "Default tint2rc" "bl-text-editor $TINT2RC"
     menuSubmenu "RunningTint2" "Running Tint2s"
     if [ "$(pidof tint2)" ];then
-        while read tsession ;do  # get running tint2s from sessionfile
-            TPATH=$(echo "$tsession" | awk '{print $3}')
-            TINT2=$(echo "$TPATH" | awk -F"/" '{print $(NF-1)"/"$NF }')
+        # test if default tint2 was started (exclude this script from list)
+        for FIELD in $(ps aux | grep -v 'zenity\|bl-tint2' | grep  [t]int2 | awk '{print $NF}');do
+            if [[ $FIELD = "tint2" ]]; then
+                TINT2=$(echo "Default tint2rc") # 'tint2' command was used
+                TPATH="$TINT2PATH/tint2rc"
+            else
+                TINT2=$(echo $FIELD | awk -F"/" '{print $(NF-1)"/"$NF }')
+                TPATH="$FIELD"
+            fi
             menuItem "$TINT2" "bl-text-editor $TPATH"
-        done < "$TSESSIONFILE"
+        done
     else 
         menuItem "No tint2s running" 
     fi


### PR DESCRIPTION
Find running tint2s, instead of reading from session file. Includes tint2rc if started with `tint2` command
