### PR TITLE
use python3

### DIFF
--- a/bin/bl-sshconfig-pipemenu
+++ b/bin/bl-sshconfig-pipemenu
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 #    bl-sshconfig-pipemenu - an Openbox pipemenu for Graphics applications
 #    Copyright (C) 2012 Philip Newborough   <corenominal@corenominal.org>
 #    Copyright (C) 2015  Ankur Khanna
@@ -54,20 +54,20 @@ else:
     config.parse(config_file)
     hosts = config._config
 
-print '<openbox_pipe_menu>'
+print('<openbox_pipe_menu>')
 
 need_separator = False
 if not  os.access('/usr/sbin/sshd', os.X_OK):
-    print ('<menu id="ssh install" label="SSH server">')
-    print ('    <item label="Install OpenSSH server">')
-    print ('        <action name="Execute">')
-    print ('            <command>')
-    print ('                bl-install --name &apos;OpenSSH server and client&apos; bunsen-meta-ssh')
-    print ('            </command>')
-    print ('        </action>')
-    print ('    </item>')
-    print ('</menu>')
-    print ('<separator/>')
+    print('<menu id="ssh install" label="SSH server">')
+    print('    <item label="Install OpenSSH server">')
+    print('        <action name="Execute">')
+    print('            <command>')
+    print('                bl-install --name &apos;OpenSSH server and client&apos; bunsen-meta-ssh')
+    print('            </command>')
+    print('        </action>')
+    print('    </item>')
+    print('</menu>')
+    print('<separator/>')
 if len(hosts) >= 2:
     for host_entries in hosts:
         for host_name in host_entries['host']:
@@ -77,28 +77,28 @@ if len(hosts) >= 2:
                               ' || echo &quot;Press any key to close this window&quot;; read REPLY&apos;'
                 # build a ssh for filesystem command
                 fs_command = 'bl-file-manager ssh://' + host_name
-                print ('<menu id="' + host_name + '" label="' + host_name + '">')
-                print ('    <item label="Start terminal session">')
-                print ('        <action name="Execute">')
-                print ('            <command>')
-                print ('                ' + ssh_command)
-                print ('            </command>')
-                print ('        </action>')
-                print ('    </item>')
-                print ('    <item label="Browse with File Manager">')
-                print ('        <action name="Execute">')
-                print ('            <command>')
-                print ('                ' + fs_command)
-                print ('            </command>')
-                print ('        </action>')
-                print ('    </item>')
-                print ('</menu>')
-print ('<separator/>')
-print ('<item label="Edit ~/.ssh/config">')
-print ('    <action name="Execute">')
-print ('        <command>')
-print ('            bl-text-editor ~/.ssh/config')
-print ('        </command>')
-print ('    </action>')
-print ('</item>')
-print ('</openbox_pipe_menu>')
+                print('<menu id="' + host_name + '" label="' + host_name + '">')
+                print('    <item label="Start terminal session">')
+                print('        <action name="Execute">')
+                print('            <command>')
+                print('                ' + ssh_command)
+                print('            </command>')
+                print('        </action>')
+                print('    </item>')
+                print('    <item label="Browse with File Manager">')
+                print('        <action name="Execute">')
+                print('            <command>')
+                print('                ' + fs_command)
+                print('            </command>')
+                print('        </action>')
+                print('    </item>')
+                print('</menu>')
+print('<separator/>')
+print('<item label="Edit ~/.ssh/config">')
+print('    <action name="Execute">')
+print('        <command>')
+print('            bl-text-editor ~/.ssh/config')
+print('        </command>')
+print('    </action>')
+print('</item>')
+print('</openbox_pipe_menu>')

--- a/debian/control
+++ b/debian/control
@@ -8,8 +8,8 @@ Build-Depends: debhelper (>= 10),
  lua-posix,
  lua-socket,
  lua-penlight,
- python,
- python-paramiko
+ python3,
+ python3-paramiko
 Standards-Version: 4.3.0
 Homepage: https://github.com/BunsenLabs/bunsen-pipemenus
 Vcs-Git: https://github.com/BunsenLabs/bunsen-pipemenus.git
@@ -22,8 +22,8 @@ Depends: ${misc:Depends},
  xterm | x-terminal-emulator,
  yad,
  wget,
- python,
- python-paramiko,
+ python3,
+ python3-paramiko,
  mesa-utils,
  lua5.2,
  lua-expat,


### PR DESCRIPTION
At least with Debian Testing, most dependencies on python2 are gone when running a minimal desktop system. bl-pipemenus is one of the few packages (on my system) with a hard dependency on it.