### PR TITLE
Update bl-recent-files-pipemenu

### DIFF
--- a/bin/bl-recent-files-pipemenu
+++ b/bin/bl-recent-files-pipemenu
@@ -28,7 +28,9 @@ end
 local M = xml.new("openbox_pipe_menu")
 
 local function quote(s)
-  return string.format("%q", s)
+  s = s:gsub("'", "'\\''")
+  s = "'" .. s .. "'"
+  return s
 end
 
 local function printf(f, ...)


### PR DESCRIPTION
Double-quoting file paths opens a possible vulnerability: words in filenames following a dollar sign will be treated as variables and expanded when opening from the menu. 

**Test:** create a file named $HOME, open it in a text editor so it is added to recently-used.xbel, then open it from the recent files menu. The editor will open a new file named */home/[username]*

**EDIT:** The issue does not appear when using the generated xml menu directly with openbox, but only via jgmenu's *jgmenu_run ob* module. Presumably the shell is invoked by jgmenu to interpret file paths. I think it's still a potential vulnerability that we might as well avoid, however, since the fix looks simple.

The fix is to quote filepaths with single quotes, but please check my proposed quote() function.